### PR TITLE
fix: exception raised for ruby versions < 2.6

### DIFF
--- a/application.rb
+++ b/application.rb
@@ -81,5 +81,10 @@ class MiniApp < Rails::Application
   end
 end
 
-system "yarn && yarn build", exception: true
+if RUBY_VERSION.to_f > 2.5 
+  system "yarn && yarn build", exception: true
+else
+  system "yarn && yarn build"
+end
+
 Rails::Server.new(app: MiniApp, Host: "0.0.0.0", Port: 3000).start


### PR DESCRIPTION
PR type: Bug fix

Currently application.rb throws an exception for Ruby versions < 2.6 as system exception: true was added in Ruby 2.6.

This PR fixes that issue and allows everyone to enjoy this amazing project. 

Related to #2